### PR TITLE
fix: update deprecated text-embedding-004 to gemini-embedding-001

### DIFF
--- a/starguide_server/lib/src/generative_ai/generative_ai.dart
+++ b/starguide_server/lib/src/generative_ai/generative_ai.dart
@@ -173,8 +173,8 @@ extension RAGDocumentTypeName on RAGDocumentType {
 }
 
 enum ModelQuality {
-  fast('google?chat=gemini-2.5-flash-lite&embeddings=text-embedding-004'),
-  smart('google?chat=gemini-2.5-flash&embeddings=text-embedding-004');
+  fast('google?chat=gemini-2.5-flash-lite&embeddings=gemini-embedding-001'),
+  smart('google?chat=gemini-2.5-flash&embeddings=gemini-embedding-001');
 
   const ModelQuality(this.model);
 


### PR DESCRIPTION
Updates the deprecated text-embedding-004 embedding model to gemini-embedding-001. Google shut down text-embedding-004 on January 14, 2026. Fixes #6